### PR TITLE
[bug]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,132 +1,154 @@
 # Changelog for specification
 
-## [v0.15.28](https://github.com/volkmarnissen/specification/tree/v0.15.28) (2025-01-16)
+## [Unreleased](https://github.com/modbus2mqtt/specification/tree/HEAD)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.27...v0.15.28)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.29...HEAD)
 
-## [v0.15.27](https://github.com/volkmarnissen/specification/tree/v0.15.27) (2025-01-15)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.26...v0.15.27)
+- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/specification/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
+- Fix Modbuscache, Add caching for modbusRTU [\#4](https://github.com/modbus2mqtt/specification/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
 
-## [v0.15.26](https://github.com/volkmarnissen/specification/tree/v0.15.26) (2025-01-02)
+## [v0.15.29](https://github.com/modbus2mqtt/specification/tree/v0.15.29) (2025-04-14)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.25...v0.15.26)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.28...v0.15.29)
 
-## [v0.15.25](https://github.com/volkmarnissen/specification/tree/v0.15.25) (2024-12-22)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.24...v0.15.25)
+- Infrastructure fixes [\#3](https://github.com/modbus2mqtt/specification/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
+- Adding discrete inputs to data structures [\#2](https://github.com/modbus2mqtt/specification/pull/2) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.15.24](https://github.com/volkmarnissen/specification/tree/v0.15.24) (2024-12-13)
+## [v0.15.28](https://github.com/modbus2mqtt/specification/tree/v0.15.28) (2025-01-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.23...v0.15.24)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.27...v0.15.28)
 
-## [v0.15.23](https://github.com/volkmarnissen/specification/tree/v0.15.23) (2024-12-13)
+## [v0.15.27](https://github.com/modbus2mqtt/specification/tree/v0.15.27) (2025-01-15)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.22...v0.15.23)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.26...v0.15.27)
 
-## [v0.15.22](https://github.com/volkmarnissen/specification/tree/v0.15.22) (2024-12-11)
+## [v0.15.26](https://github.com/modbus2mqtt/specification/tree/v0.15.26) (2025-01-02)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.21...v0.15.22)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.25...v0.15.26)
 
-## [v0.15.21](https://github.com/volkmarnissen/specification/tree/v0.15.21) (2024-11-22)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.20...v0.15.21)
+- Adding support for converting int32 and uint32 numbers [\#1](https://github.com/modbus2mqtt/specification/pull/1) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.15.20](https://github.com/volkmarnissen/specification/tree/v0.15.20) (2024-11-16)
+## [v0.15.25](https://github.com/modbus2mqtt/specification/tree/v0.15.25) (2024-12-22)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.19...v0.15.20)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.24...v0.15.25)
 
-## [v0.15.19](https://github.com/volkmarnissen/specification/tree/v0.15.19) (2024-11-14)
+## [v0.15.24](https://github.com/modbus2mqtt/specification/tree/v0.15.24) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.18...v0.15.19)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.23...v0.15.24)
 
-## [v0.15.18](https://github.com/volkmarnissen/specification/tree/v0.15.18) (2024-10-23)
+## [v0.15.23](https://github.com/modbus2mqtt/specification/tree/v0.15.23) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.17...v0.15.18)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.22...v0.15.23)
 
-## [v0.15.17](https://github.com/volkmarnissen/specification/tree/v0.15.17) (2024-10-16)
+## [v0.15.22](https://github.com/modbus2mqtt/specification/tree/v0.15.22) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.16...v0.15.17)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.21...v0.15.22)
 
-## [v0.15.16](https://github.com/volkmarnissen/specification/tree/v0.15.16) (2024-09-24)
+## [v0.15.21](https://github.com/modbus2mqtt/specification/tree/v0.15.21) (2024-11-22)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.15...v0.15.16)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.20...v0.15.21)
 
-## [v0.15.15](https://github.com/volkmarnissen/specification/tree/v0.15.15) (2024-09-16)
+## [v0.15.20](https://github.com/modbus2mqtt/specification/tree/v0.15.20) (2024-11-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.14...v0.15.15)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.19...v0.15.20)
 
-## [v0.15.14](https://github.com/volkmarnissen/specification/tree/v0.15.14) (2024-09-09)
+## [v0.15.19](https://github.com/modbus2mqtt/specification/tree/v0.15.19) (2024-11-14)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.13...v0.15.14)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.18...v0.15.19)
 
-## [v0.15.13](https://github.com/volkmarnissen/specification/tree/v0.15.13) (2024-09-09)
+## [v0.15.18](https://github.com/modbus2mqtt/specification/tree/v0.15.18) (2024-10-23)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.12...v0.15.13)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.17...v0.15.18)
 
-## [v0.15.12](https://github.com/volkmarnissen/specification/tree/v0.15.12) (2024-09-09)
+## [v0.15.17](https://github.com/modbus2mqtt/specification/tree/v0.15.17) (2024-10-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.11...v0.15.12)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.16...v0.15.17)
 
-## [v0.15.11](https://github.com/volkmarnissen/specification/tree/v0.15.11) (2024-09-06)
+## [v0.15.16](https://github.com/modbus2mqtt/specification/tree/v0.15.16) (2024-09-24)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.10...v0.15.11)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.15...v0.15.16)
 
-## [v0.15.10](https://github.com/volkmarnissen/specification/tree/v0.15.10) (2024-09-06)
+## [v0.15.15](https://github.com/modbus2mqtt/specification/tree/v0.15.15) (2024-09-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.9...v0.15.10)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.14...v0.15.15)
 
-## [v0.15.9](https://github.com/volkmarnissen/specification/tree/v0.15.9) (2024-09-06)
+## [v0.15.14](https://github.com/modbus2mqtt/specification/tree/v0.15.14) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.8...v0.15.9)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.13...v0.15.14)
 
-## [v0.15.8](https://github.com/volkmarnissen/specification/tree/v0.15.8) (2024-09-06)
+## [v0.15.13](https://github.com/modbus2mqtt/specification/tree/v0.15.13) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.7...v0.15.8)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.12...v0.15.13)
 
-## [v0.15.7](https://github.com/volkmarnissen/specification/tree/v0.15.7) (2024-09-06)
+## [v0.15.12](https://github.com/modbus2mqtt/specification/tree/v0.15.12) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.6...v0.15.7)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.11...v0.15.12)
 
-## [v0.15.6](https://github.com/volkmarnissen/specification/tree/v0.15.6) (2024-09-06)
+## [v0.15.11](https://github.com/modbus2mqtt/specification/tree/v0.15.11) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.5...v0.15.6)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.10...v0.15.11)
 
-## [v0.15.5](https://github.com/volkmarnissen/specification/tree/v0.15.5) (2024-09-06)
+## [v0.15.10](https://github.com/modbus2mqtt/specification/tree/v0.15.10) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.4...v0.15.5)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.9...v0.15.10)
 
-## [v0.15.4](https://github.com/volkmarnissen/specification/tree/v0.15.4) (2024-09-06)
+## [v0.15.9](https://github.com/modbus2mqtt/specification/tree/v0.15.9) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.2...v0.15.4)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.8...v0.15.9)
 
-## [v0.15.2](https://github.com/volkmarnissen/specification/tree/v0.15.2) (2024-09-06)
+## [v0.15.8](https://github.com/modbus2mqtt/specification/tree/v0.15.8) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.7...v0.15.8)
 
-## [v0.15.1](https://github.com/volkmarnissen/specification/tree/v0.15.1) (2024-09-06)
+## [v0.15.7](https://github.com/modbus2mqtt/specification/tree/v0.15.7) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.0...v0.15.1)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.6...v0.15.7)
 
-## [v0.15.0](https://github.com/volkmarnissen/specification/tree/v0.15.0) (2024-08-16)
+## [v0.15.6](https://github.com/modbus2mqtt/specification/tree/v0.15.6) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.14.0...v0.15.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.5...v0.15.6)
 
-## [v0.14.0](https://github.com/volkmarnissen/specification/tree/v0.14.0) (2024-08-06)
+## [v0.15.5](https://github.com/modbus2mqtt/specification/tree/v0.15.5) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.13.0...v0.14.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.4...v0.15.5)
 
-## [v0.13.0](https://github.com/volkmarnissen/specification/tree/v0.13.0) (2024-08-06)
+## [v0.15.4](https://github.com/modbus2mqtt/specification/tree/v0.15.4) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.11.0...v0.13.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.2...v0.15.4)
 
-## [v0.11.0](https://github.com/volkmarnissen/specification/tree/v0.11.0) (2024-08-05)
+## [v0.15.2](https://github.com/modbus2mqtt/specification/tree/v0.15.2) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.10.0...v0.11.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.1...v0.15.2)
 
-## [v0.10.0](https://github.com/volkmarnissen/specification/tree/v0.10.0) (2024-08-05)
+## [v0.15.1](https://github.com/modbus2mqtt/specification/tree/v0.15.1) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.0...v0.15.1)
+
+## [v0.15.0](https://github.com/modbus2mqtt/specification/tree/v0.15.0) (2024-08-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.14.0...v0.15.0)
+
+## [v0.14.0](https://github.com/modbus2mqtt/specification/tree/v0.14.0) (2024-08-06)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.13.0...v0.14.0)
+
+## [v0.13.0](https://github.com/modbus2mqtt/specification/tree/v0.13.0) (2024-08-06)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.11.0...v0.13.0)
+
+## [v0.11.0](https://github.com/modbus2mqtt/specification/tree/v0.11.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.10.0...v0.11.0)
+
+## [v0.10.0](https://github.com/modbus2mqtt/specification/tree/v0.10.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,154 +1,132 @@
 # Changelog for specification
 
-## [Unreleased](https://github.com/modbus2mqtt/specification/tree/HEAD)
+## [v0.15.28](https://github.com/volkmarnissen/specification/tree/v0.15.28) (2025-01-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.29...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.27...v0.15.28)
 
-**Merged pull requests:**
+## [v0.15.27](https://github.com/volkmarnissen/specification/tree/v0.15.27) (2025-01-15)
 
-- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/specification/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
-- Fix Modbuscache, Add caching for modbusRTU [\#4](https://github.com/modbus2mqtt/specification/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.26...v0.15.27)
 
-## [v0.15.29](https://github.com/modbus2mqtt/specification/tree/v0.15.29) (2025-04-14)
+## [v0.15.26](https://github.com/volkmarnissen/specification/tree/v0.15.26) (2025-01-02)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.28...v0.15.29)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.25...v0.15.26)
 
-**Merged pull requests:**
+## [v0.15.25](https://github.com/volkmarnissen/specification/tree/v0.15.25) (2024-12-22)
 
-- Infrastructure fixes [\#3](https://github.com/modbus2mqtt/specification/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- Adding discrete inputs to data structures [\#2](https://github.com/modbus2mqtt/specification/pull/2) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.24...v0.15.25)
 
-## [v0.15.28](https://github.com/modbus2mqtt/specification/tree/v0.15.28) (2025-01-16)
+## [v0.15.24](https://github.com/volkmarnissen/specification/tree/v0.15.24) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.27...v0.15.28)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.23...v0.15.24)
 
-## [v0.15.27](https://github.com/modbus2mqtt/specification/tree/v0.15.27) (2025-01-15)
+## [v0.15.23](https://github.com/volkmarnissen/specification/tree/v0.15.23) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.26...v0.15.27)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.22...v0.15.23)
 
-## [v0.15.26](https://github.com/modbus2mqtt/specification/tree/v0.15.26) (2025-01-02)
+## [v0.15.22](https://github.com/volkmarnissen/specification/tree/v0.15.22) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.25...v0.15.26)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.21...v0.15.22)
 
-**Merged pull requests:**
+## [v0.15.21](https://github.com/volkmarnissen/specification/tree/v0.15.21) (2024-11-22)
 
-- Adding support for converting int32 and uint32 numbers [\#1](https://github.com/modbus2mqtt/specification/pull/1) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.20...v0.15.21)
 
-## [v0.15.25](https://github.com/modbus2mqtt/specification/tree/v0.15.25) (2024-12-22)
+## [v0.15.20](https://github.com/volkmarnissen/specification/tree/v0.15.20) (2024-11-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.24...v0.15.25)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.19...v0.15.20)
 
-## [v0.15.24](https://github.com/modbus2mqtt/specification/tree/v0.15.24) (2024-12-13)
+## [v0.15.19](https://github.com/volkmarnissen/specification/tree/v0.15.19) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.23...v0.15.24)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.18...v0.15.19)
 
-## [v0.15.23](https://github.com/modbus2mqtt/specification/tree/v0.15.23) (2024-12-13)
+## [v0.15.18](https://github.com/volkmarnissen/specification/tree/v0.15.18) (2024-10-23)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.22...v0.15.23)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.17...v0.15.18)
 
-## [v0.15.22](https://github.com/modbus2mqtt/specification/tree/v0.15.22) (2024-12-11)
+## [v0.15.17](https://github.com/volkmarnissen/specification/tree/v0.15.17) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.21...v0.15.22)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.16...v0.15.17)
 
-## [v0.15.21](https://github.com/modbus2mqtt/specification/tree/v0.15.21) (2024-11-22)
+## [v0.15.16](https://github.com/volkmarnissen/specification/tree/v0.15.16) (2024-09-24)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.20...v0.15.21)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.15...v0.15.16)
 
-## [v0.15.20](https://github.com/modbus2mqtt/specification/tree/v0.15.20) (2024-11-16)
+## [v0.15.15](https://github.com/volkmarnissen/specification/tree/v0.15.15) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.19...v0.15.20)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.14...v0.15.15)
 
-## [v0.15.19](https://github.com/modbus2mqtt/specification/tree/v0.15.19) (2024-11-14)
+## [v0.15.14](https://github.com/volkmarnissen/specification/tree/v0.15.14) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.18...v0.15.19)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.13...v0.15.14)
 
-## [v0.15.18](https://github.com/modbus2mqtt/specification/tree/v0.15.18) (2024-10-23)
+## [v0.15.13](https://github.com/volkmarnissen/specification/tree/v0.15.13) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.17...v0.15.18)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.12...v0.15.13)
 
-## [v0.15.17](https://github.com/modbus2mqtt/specification/tree/v0.15.17) (2024-10-16)
+## [v0.15.12](https://github.com/volkmarnissen/specification/tree/v0.15.12) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.16...v0.15.17)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.11...v0.15.12)
 
-## [v0.15.16](https://github.com/modbus2mqtt/specification/tree/v0.15.16) (2024-09-24)
+## [v0.15.11](https://github.com/volkmarnissen/specification/tree/v0.15.11) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.15...v0.15.16)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.10...v0.15.11)
 
-## [v0.15.15](https://github.com/modbus2mqtt/specification/tree/v0.15.15) (2024-09-16)
+## [v0.15.10](https://github.com/volkmarnissen/specification/tree/v0.15.10) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.14...v0.15.15)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.9...v0.15.10)
 
-## [v0.15.14](https://github.com/modbus2mqtt/specification/tree/v0.15.14) (2024-09-09)
+## [v0.15.9](https://github.com/volkmarnissen/specification/tree/v0.15.9) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.13...v0.15.14)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.8...v0.15.9)
 
-## [v0.15.13](https://github.com/modbus2mqtt/specification/tree/v0.15.13) (2024-09-09)
+## [v0.15.8](https://github.com/volkmarnissen/specification/tree/v0.15.8) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.12...v0.15.13)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.7...v0.15.8)
 
-## [v0.15.12](https://github.com/modbus2mqtt/specification/tree/v0.15.12) (2024-09-09)
+## [v0.15.7](https://github.com/volkmarnissen/specification/tree/v0.15.7) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.11...v0.15.12)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.6...v0.15.7)
 
-## [v0.15.11](https://github.com/modbus2mqtt/specification/tree/v0.15.11) (2024-09-06)
+## [v0.15.6](https://github.com/volkmarnissen/specification/tree/v0.15.6) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.10...v0.15.11)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.5...v0.15.6)
 
-## [v0.15.10](https://github.com/modbus2mqtt/specification/tree/v0.15.10) (2024-09-06)
+## [v0.15.5](https://github.com/volkmarnissen/specification/tree/v0.15.5) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.9...v0.15.10)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.4...v0.15.5)
 
-## [v0.15.9](https://github.com/modbus2mqtt/specification/tree/v0.15.9) (2024-09-06)
+## [v0.15.4](https://github.com/volkmarnissen/specification/tree/v0.15.4) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.8...v0.15.9)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.2...v0.15.4)
 
-## [v0.15.8](https://github.com/modbus2mqtt/specification/tree/v0.15.8) (2024-09-06)
+## [v0.15.2](https://github.com/volkmarnissen/specification/tree/v0.15.2) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.7...v0.15.8)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.1...v0.15.2)
 
-## [v0.15.7](https://github.com/modbus2mqtt/specification/tree/v0.15.7) (2024-09-06)
+## [v0.15.1](https://github.com/volkmarnissen/specification/tree/v0.15.1) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.6...v0.15.7)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.0...v0.15.1)
 
-## [v0.15.6](https://github.com/modbus2mqtt/specification/tree/v0.15.6) (2024-09-06)
+## [v0.15.0](https://github.com/volkmarnissen/specification/tree/v0.15.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.5...v0.15.6)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.14.0...v0.15.0)
 
-## [v0.15.5](https://github.com/modbus2mqtt/specification/tree/v0.15.5) (2024-09-06)
+## [v0.14.0](https://github.com/volkmarnissen/specification/tree/v0.14.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.4...v0.15.5)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.13.0...v0.14.0)
 
-## [v0.15.4](https://github.com/modbus2mqtt/specification/tree/v0.15.4) (2024-09-06)
+## [v0.13.0](https://github.com/volkmarnissen/specification/tree/v0.13.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.2...v0.15.4)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.11.0...v0.13.0)
 
-## [v0.15.2](https://github.com/modbus2mqtt/specification/tree/v0.15.2) (2024-09-06)
+## [v0.11.0](https://github.com/volkmarnissen/specification/tree/v0.11.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.10.0...v0.11.0)
 
-## [v0.15.1](https://github.com/modbus2mqtt/specification/tree/v0.15.1) (2024-09-06)
+## [v0.10.0](https://github.com/volkmarnissen/specification/tree/v0.10.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.0...v0.15.1)
-
-## [v0.15.0](https://github.com/modbus2mqtt/specification/tree/v0.15.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.14.0...v0.15.0)
-
-## [v0.14.0](https://github.com/modbus2mqtt/specification/tree/v0.14.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.13.0...v0.14.0)
-
-## [v0.13.0](https://github.com/modbus2mqtt/specification/tree/v0.13.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.11.0...v0.13.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/specification/tree/v0.11.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.10.0...v0.11.0)
-
-## [v0.10.0](https://github.com/modbus2mqtt/specification/tree/v0.10.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
 
 
 

--- a/__tests__/Ientity_test.tsx
+++ b/__tests__/Ientity_test.tsx
@@ -3,7 +3,7 @@ import { cleanConverterParameters, removeModbusData } from '@modbus2mqtt/specifi
 
 var entity: any = {
   name: 'test',
-  converter: { name: 'number', functionCodes: [] },
+  converter: 'number',
   modbusValue: [3, 4, 5],
   mqttValue: 3,
   converterParameters: { uom: 'kW', multiplier: 1, tobeRemoved: 'tobeREmoved' },

--- a/__tests__/convertermap_test.tsx
+++ b/__tests__/convertermap_test.tsx
@@ -9,7 +9,7 @@ let spec: Ispecification = {
     {
       id: 1,
       mqttname: 'mqtt',
-      converter: { name: 'number' as Converters, registerTypes: [] },
+      converter: 'number' as Converters,
       modbusAddress: 4,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: true,
@@ -19,7 +19,7 @@ let spec: Ispecification = {
     {
       id: 2,
       mqttname: 'mqtt2',
-      converter: { name: 'select_sensor' as Converters, registerTypes: [] },
+      converter: 'select_sensor' as Converters,
       modbusAddress: 2,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: true,
@@ -29,7 +29,7 @@ let spec: Ispecification = {
     {
       id: 3,
       mqttname: 'mqtt3',
-      converter: { name: 'select_sensor' as Converters, registerTypes: [] },
+      converter: 'select_sensor' as Converters,
       modbusAddress: 3,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: true,
@@ -58,7 +58,7 @@ it('test sensor converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 0.01, offset: 0 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -73,7 +73,7 @@ it('test sensor converter with stringlength', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { stringlength: 10 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -89,7 +89,7 @@ it('test binary_sensor converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'binary', registerTypes: [] },
+    converter: 'binary',
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
     modbusAddress: 2,
@@ -103,7 +103,7 @@ it('test binary_sensor converter', () => {
   entity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'binary', registerTypes: [] },
+    converter: 'binary',
     converterParameters: { optionModbusValues: [0, 1] },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -117,7 +117,7 @@ it('test select_sensor converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'select', registerTypes: [] },
+    converter: 'select',
     converterParameters: { optionModbusValues: [1, 2] },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -132,7 +132,7 @@ it('test select_sensor converter', () => {
   entity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'select', registerTypes: [] },
+    converter: 'select',
     converterParameters: { optionModbusValues: [0, 1] },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -147,7 +147,7 @@ it('test text_sensor converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'text', registerTypes: [] },
+    converter: 'text',
     converterParameters: { stringlength: 10 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -167,7 +167,7 @@ it('test value_sensor converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'value', registerTypes: [] },
+    converter: 'value',
     converterParameters: { value: 'testValue' },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -183,7 +183,7 @@ it('test text converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'text', registerTypes: [] },
+    converter: 'text',
     converterParameters: { stringlength: 10 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -203,7 +203,7 @@ it('test number converter ignore decimal places when returning float', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 0.01, offset: 0, decimals: 1 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -220,7 +220,7 @@ it('test number converter ignore decimal places when returning float', () => {
   entity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 0.01, offset: 20 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -234,7 +234,7 @@ it('test number float', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.float32 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -253,7 +253,7 @@ it('test number signed int16', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt16 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -271,7 +271,7 @@ it('test number signed int32 - positive', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt32 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -290,7 +290,7 @@ it('test number signed int32 - positive max', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt32 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -309,7 +309,7 @@ it('test number signed int32 - negative', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.signedInt32 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -329,7 +329,7 @@ it('test number unsigned int32 - max', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'number', registerTypes: [] },
+    converter: 'number',
     converterParameters: { multiplier: 1, offset: 0, numberFormat: EnumNumberFormat.unsignedInt32 },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -349,7 +349,7 @@ it('test select converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'select', registerTypes: [] },
+    converter: 'select',
     converterParameters: { optionModbusValues: [1, 2] },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -362,7 +362,7 @@ it('test select converter', () => {
   entity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'select', registerTypes: [] },
+    converter: 'select',
     converterParameters: { optionModbusValues: [1, 2] },
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
@@ -375,7 +375,7 @@ it('test button converter', () => {
   let entity: Ientity = {
     id: 1,
     mqttname: 'mqtt',
-    converter: { name: 'binary', registerTypes: [] },
+    converter: 'binary',
     registerType: ModbusRegisterType.HoldingRegister,
     readonly: false,
     modbusAddress: 2,

--- a/__tests__/m2mspecification_test.tsx
+++ b/__tests__/m2mspecification_test.tsx
@@ -40,7 +40,7 @@ var entText: ImodbusEntity = {
   mqttValue: '',
   identified: IdentifiedStates.unknown,
   converterParameters: { stringlength: 10 },
-  converter: { name: 'text', registerTypes: [] },
+  converter: 'text',
 }
 
 let spec: IfileSpecification = {
@@ -48,7 +48,7 @@ let spec: IfileSpecification = {
     {
       id: 1,
       mqttname: 'mqtt',
-      converter: { name: 'number' as Converters, registerTypes: [] },
+      converter: 'number' as Converters,
       modbusAddress: 3,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: true,
@@ -58,7 +58,7 @@ let spec: IfileSpecification = {
     {
       id: 2,
       mqttname: 'mqtt2',
-      converter: { name: 'select' as Converters, registerTypes: [] },
+      converter: 'select' as Converters,
       modbusAddress: 4,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: true,
@@ -68,7 +68,7 @@ let spec: IfileSpecification = {
     {
       id: 3,
       mqttname: 'mqtt3',
-      converter: { name: 'select' as Converters, registerTypes: [] },
+      converter: 'select' as Converters,
       modbusAddress: 5,
       registerType: ModbusRegisterType.HoldingRegister,
       readonly: false,

--- a/__tests__/migrator_test.tsx
+++ b/__tests__/migrator_test.tsx
@@ -11,7 +11,7 @@ it('check device type status', () => {
   let spec = ConfigSpecification.getSpecificationByFilename('dimplexpco5')
   expect(spec?.testdata.holdingRegisters?.length).toBeGreaterThan(0)
   spec?.entities.forEach((e) => {
-    expect(e.converter.name.indexOf('sensor')).toBe(-1)
+    expect(e.converter.indexOf('sensor')).toBe(-1)
     expect((e as any).functionCode).toBeUndefined()
     expect(e.readonly).toBeDefined()
     expect(e.registerType).toBeDefined()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,7 +1626,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#41f7eabb3f13ffdbb5bf69fc8b7f201ca3ffb2d9",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#61320c92e4f2ed98476d79ef7b12684ad8ba8288",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/src/configspec.ts
+++ b/src/configspec.ts
@@ -165,9 +165,7 @@ export class ConfigSpecification {
           o.filename = newfn
           this.readFilesYaml(directory, o)
           o.entities.forEach((entity) => {
-            let cv = ConverterMap.getIConverter(entity)
-            if (cv) {
-              entity.converter = cv
+            if (entity.converter != undefined) {
               let inumber = entity.converterParameters as Inumber
               if (inumber.multiplier != undefined && inumber.numberFormat == undefined) {
                 inumber.numberFormat = EnumNumberFormat.default
@@ -302,8 +300,7 @@ export class ConfigSpecification {
               })
               break
           }
-          entity.converter.registerTypes = []
-        }
+         }
     })
     if (fileSpec.testdata.analogInputs?.length == 0) delete fileSpec.testdata.analogInputs
     if (fileSpec.testdata.holdingRegisters?.length == 0) delete fileSpec.testdata.holdingRegisters
@@ -561,7 +558,10 @@ export class ConfigSpecification {
     delete (spec as any).identified
   }
 
-  static getSpecificationByFilename(filename: string): IfileSpecification | undefined {
+  static getSpecificationByFilename(filename: string|undefined): IfileSpecification | undefined {
+    if (filename == undefined) 
+      return undefined
+  
     if (filename == '_new') {
       let rc: IfileSpecification = {
         version: SPECIFICATION_VERSION,

--- a/src/convertermap.ts
+++ b/src/convertermap.ts
@@ -3,7 +3,7 @@ import { NumberConverter } from './numberConverter'
 import { TextConverter } from './textConverter'
 import { SelectConverter } from './selectConverter'
 import { ValueConverter } from './valueconverter'
-import { Ientity, Iconverter, Converters } from '@modbus2mqtt/specification.shared'
+import { Ientity, Converters } from '@modbus2mqtt/specification.shared'
 import { BinaryConverter } from './binaryConverter'
 import { ConfigSpecification } from './configspec'
 
@@ -13,43 +13,17 @@ export class ConverterMap extends Map<Converters, Converter> {
     return ConverterMap.converterMap
   }
 
-  static getConverters(): Iconverter[] {
-    let rc: Iconverter[] = []
+  static getConverters(): Converters[] {
+    let rc: Converters[] = []
     ConverterMap.getConverterMap().forEach((con, name) => {
-      let c: Iconverter = {
-        name: name,
-        registerTypes: con.getModbusRegisterTypes(),
-      }
-      rc.push(c)
+      rc.push(name)
     })
     return rc
   }
-  static getIConverter(entity: Ientity): Iconverter | undefined {
-    let cv: Converter | undefined = undefined
-    if (entity.converter) cv = this.getConverterMap().get(entity.converter.name)
-    if (cv) {
-      let c: Iconverter = {
-        name: entity.converter.name,
-        registerTypes: cv.getModbusRegisterTypes(),
-      }
-      return c
-    }
-    return undefined
-  }
-  // static getConverters(): Iconverter[] {
-  //     let rc:Iconverter[] =[]
-  //     ConverterMap.getConverterMap().forEach((con, name)=>{
-  //         let c:Iconverter={
-  //             name: name,
-  //             functionCodes:con.getModbusFunctionCodes()
-  //         }
-  //         rc.push(c)
-  //     })
-  //     return rc;
-  // }
+
   static getConverter(entity: Ientity): Converter | undefined {
     let cv: Converter | undefined = undefined
-    if (entity.converter) cv = this.getConverterMap().get(entity.converter.name)
+    if (entity.converter) cv = ConverterMap.getConverterMap().get(entity.converter)
     return cv
   }
   //@ts-ignore

--- a/src/m2mspecification.ts
+++ b/src/m2mspecification.ts
@@ -509,7 +509,7 @@ export class M2mSpecification implements IspecificationValidator {
               let mqtt = converter.modbus2mqtt(spec, entity.id, data)
               let identified = IdentifiedStates.unknown
               if (entity.converterParameters)
-                if (entity.converter.name === 'number') {
+                if (entity.converter === 'number') {
                   if (!(entity.converterParameters as Inumber).identification)
                     (entity as ImodbusEntity).identified = IdentifiedStates.unknown
                   else {
@@ -559,7 +559,7 @@ export class M2mSpecification implements IspecificationValidator {
       } else
         log.log(
           LogLevelEnum.error,
-          'Converter not found: ' + spec.filename + ' ' + entity.converter.name + ' entity id: ' + +entity.id
+          'Converter not found: ' + spec.filename + ' ' + entity.converter + ' entity id: ' + +entity.id
         )
 
       return rc
@@ -728,7 +728,7 @@ export class M2mSpecification implements IspecificationValidator {
           additionalInformation: getSpecificationI18nEntityName(other, 'en', oent.id),
         })
       else {
-        if (!this.isEqualValue(oent.converter.name, ent.converter.name))
+        if (!this.isEqualValue(oent.converter, ent.converter))
           rc.push({ type: MessageTypes.differentConverter, category: MessageCategories.compareEntity, referencedEntity: ent.id })
         if (!this.isEqualValue(oent.modbusAddress, ent.modbusAddress))
           rc.push({

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -1,7 +1,9 @@
 import { IModbusData, Idata, IfileSpecification } from './ifilespecification'
 import {
   FileLocation,
+  Ientity,
   IimageAndDocumentUrl,
+  Ispecification,
   ModbusRegisterType,
   SPECIFICATION_FILES_VERSION,
   SPECIFICATION_VERSION,
@@ -43,6 +45,9 @@ export class Migrator {
         case '0.2':
           filecontent = this.migrate0_2to0_3(filecontent)
           break
+        case '0.3':
+            filecontent = this.migrate0_3to0_4(filecontent)
+        break
         case SPECIFICATION_VERSION:
           return filecontent
         default:
@@ -173,7 +178,12 @@ export class Migrator {
     }
     return filecontent
   }
-
+  migrate0_3to0_4(filecontent: any): IfileSpecification {
+    filecontent.version = '0.4'
+    if (filecontent.entities) 
+      filecontent.entities.forEach((e:any)=>e.converter = e.converter.name )
+    return filecontent
+  }
   getConvertername0_1(converter: string): string {
     switch (converter) {
       case 'sensor':

--- a/src/textConverter.ts
+++ b/src/textConverter.ts
@@ -17,7 +17,7 @@ export class TextConverter extends Converter {
   }
   override modbus2mqtt(spec: Ispecification, entityid: number, value: number[]): number | string {
     let entity = spec.entities.find((e) => e.id == entityid)
-    if (entity && entity.converter.name === 'value' && entity.converterParameters && (entity.converterParameters as Ivalue).value)
+    if (entity && entity.converter === 'value' && entity.converterParameters && (entity.converterParameters as Ivalue).value)
       return (entity.converterParameters as Ivalue).value
     let cvP = entity?.converterParameters as Itext
     let buffer = Buffer.allocUnsafe(cvP.stringlength * 2)


### PR DESCRIPTION
Fixed:
- Slave UI: Specification detection did not work.
- Error Handling: Too many restarts, to many error handling slowed detection down
- Slave UI: detect specifications for new Slaves only.
- Bus: Added support for TCP RTU bridge
- Slave UI: Load complete list of specifications before spec detection
- Modbus: Use same cache for a given busid even if the Bus was recreated
### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[specification.shared](https://github.com/modbus2mqtt/specification.shared/pulls/4)|4|
|[specification](https://github.com/modbus2mqtt/specification/pulls/6)|6|
|[server.shared](https://github.com/modbus2mqtt/server.shared/pulls/2)|2|
|[angular](https://github.com/modbus2mqtt/angular/pulls/6)|6|
|[server](https://github.com/modbus2mqtt/server/pulls/112)|112|
