### PR TITLE
[Feature] Add number of processed calls to Modbus Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,157 +1,132 @@
 # Changelog for specification
 
-## [Unreleased](https://github.com/modbus2mqtt/specification/tree/HEAD)
+## [v0.15.28](https://github.com/volkmarnissen/specification/tree/v0.15.28) (2025-01-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.29...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.27...v0.15.28)
 
-**Merged pull requests:**
+## [v0.15.27](https://github.com/volkmarnissen/specification/tree/v0.15.27) (2025-01-15)
 
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/specification/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#7](https://github.com/modbus2mqtt/specification/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/specification/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
-- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/specification/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
-- Fix Modbuscache, Add caching for modbusRTU [\#4](https://github.com/modbus2mqtt/specification/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.26...v0.15.27)
 
-## [v0.15.29](https://github.com/modbus2mqtt/specification/tree/v0.15.29) (2025-04-14)
+## [v0.15.26](https://github.com/volkmarnissen/specification/tree/v0.15.26) (2025-01-02)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.28...v0.15.29)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.25...v0.15.26)
 
-**Merged pull requests:**
+## [v0.15.25](https://github.com/volkmarnissen/specification/tree/v0.15.25) (2024-12-22)
 
-- Infrastructure fixes [\#3](https://github.com/modbus2mqtt/specification/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- Adding discrete inputs to data structures [\#2](https://github.com/modbus2mqtt/specification/pull/2) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.24...v0.15.25)
 
-## [v0.15.28](https://github.com/modbus2mqtt/specification/tree/v0.15.28) (2025-01-16)
+## [v0.15.24](https://github.com/volkmarnissen/specification/tree/v0.15.24) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.27...v0.15.28)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.23...v0.15.24)
 
-## [v0.15.27](https://github.com/modbus2mqtt/specification/tree/v0.15.27) (2025-01-15)
+## [v0.15.23](https://github.com/volkmarnissen/specification/tree/v0.15.23) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.26...v0.15.27)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.22...v0.15.23)
 
-## [v0.15.26](https://github.com/modbus2mqtt/specification/tree/v0.15.26) (2025-01-02)
+## [v0.15.22](https://github.com/volkmarnissen/specification/tree/v0.15.22) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.25...v0.15.26)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.21...v0.15.22)
 
-**Merged pull requests:**
+## [v0.15.21](https://github.com/volkmarnissen/specification/tree/v0.15.21) (2024-11-22)
 
-- Adding support for converting int32 and uint32 numbers [\#1](https://github.com/modbus2mqtt/specification/pull/1) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.20...v0.15.21)
 
-## [v0.15.25](https://github.com/modbus2mqtt/specification/tree/v0.15.25) (2024-12-22)
+## [v0.15.20](https://github.com/volkmarnissen/specification/tree/v0.15.20) (2024-11-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.24...v0.15.25)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.19...v0.15.20)
 
-## [v0.15.24](https://github.com/modbus2mqtt/specification/tree/v0.15.24) (2024-12-13)
+## [v0.15.19](https://github.com/volkmarnissen/specification/tree/v0.15.19) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.23...v0.15.24)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.18...v0.15.19)
 
-## [v0.15.23](https://github.com/modbus2mqtt/specification/tree/v0.15.23) (2024-12-13)
+## [v0.15.18](https://github.com/volkmarnissen/specification/tree/v0.15.18) (2024-10-23)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.22...v0.15.23)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.17...v0.15.18)
 
-## [v0.15.22](https://github.com/modbus2mqtt/specification/tree/v0.15.22) (2024-12-11)
+## [v0.15.17](https://github.com/volkmarnissen/specification/tree/v0.15.17) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.21...v0.15.22)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.16...v0.15.17)
 
-## [v0.15.21](https://github.com/modbus2mqtt/specification/tree/v0.15.21) (2024-11-22)
+## [v0.15.16](https://github.com/volkmarnissen/specification/tree/v0.15.16) (2024-09-24)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.20...v0.15.21)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.15...v0.15.16)
 
-## [v0.15.20](https://github.com/modbus2mqtt/specification/tree/v0.15.20) (2024-11-16)
+## [v0.15.15](https://github.com/volkmarnissen/specification/tree/v0.15.15) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.19...v0.15.20)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.14...v0.15.15)
 
-## [v0.15.19](https://github.com/modbus2mqtt/specification/tree/v0.15.19) (2024-11-14)
+## [v0.15.14](https://github.com/volkmarnissen/specification/tree/v0.15.14) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.18...v0.15.19)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.13...v0.15.14)
 
-## [v0.15.18](https://github.com/modbus2mqtt/specification/tree/v0.15.18) (2024-10-23)
+## [v0.15.13](https://github.com/volkmarnissen/specification/tree/v0.15.13) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.17...v0.15.18)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.12...v0.15.13)
 
-## [v0.15.17](https://github.com/modbus2mqtt/specification/tree/v0.15.17) (2024-10-16)
+## [v0.15.12](https://github.com/volkmarnissen/specification/tree/v0.15.12) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.16...v0.15.17)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.11...v0.15.12)
 
-## [v0.15.16](https://github.com/modbus2mqtt/specification/tree/v0.15.16) (2024-09-24)
+## [v0.15.11](https://github.com/volkmarnissen/specification/tree/v0.15.11) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.15...v0.15.16)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.10...v0.15.11)
 
-## [v0.15.15](https://github.com/modbus2mqtt/specification/tree/v0.15.15) (2024-09-16)
+## [v0.15.10](https://github.com/volkmarnissen/specification/tree/v0.15.10) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.14...v0.15.15)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.9...v0.15.10)
 
-## [v0.15.14](https://github.com/modbus2mqtt/specification/tree/v0.15.14) (2024-09-09)
+## [v0.15.9](https://github.com/volkmarnissen/specification/tree/v0.15.9) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.13...v0.15.14)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.8...v0.15.9)
 
-## [v0.15.13](https://github.com/modbus2mqtt/specification/tree/v0.15.13) (2024-09-09)
+## [v0.15.8](https://github.com/volkmarnissen/specification/tree/v0.15.8) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.12...v0.15.13)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.7...v0.15.8)
 
-## [v0.15.12](https://github.com/modbus2mqtt/specification/tree/v0.15.12) (2024-09-09)
+## [v0.15.7](https://github.com/volkmarnissen/specification/tree/v0.15.7) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.11...v0.15.12)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.6...v0.15.7)
 
-## [v0.15.11](https://github.com/modbus2mqtt/specification/tree/v0.15.11) (2024-09-06)
+## [v0.15.6](https://github.com/volkmarnissen/specification/tree/v0.15.6) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.10...v0.15.11)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.5...v0.15.6)
 
-## [v0.15.10](https://github.com/modbus2mqtt/specification/tree/v0.15.10) (2024-09-06)
+## [v0.15.5](https://github.com/volkmarnissen/specification/tree/v0.15.5) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.9...v0.15.10)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.4...v0.15.5)
 
-## [v0.15.9](https://github.com/modbus2mqtt/specification/tree/v0.15.9) (2024-09-06)
+## [v0.15.4](https://github.com/volkmarnissen/specification/tree/v0.15.4) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.8...v0.15.9)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.2...v0.15.4)
 
-## [v0.15.8](https://github.com/modbus2mqtt/specification/tree/v0.15.8) (2024-09-06)
+## [v0.15.2](https://github.com/volkmarnissen/specification/tree/v0.15.2) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.7...v0.15.8)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.1...v0.15.2)
 
-## [v0.15.7](https://github.com/modbus2mqtt/specification/tree/v0.15.7) (2024-09-06)
+## [v0.15.1](https://github.com/volkmarnissen/specification/tree/v0.15.1) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.6...v0.15.7)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.0...v0.15.1)
 
-## [v0.15.6](https://github.com/modbus2mqtt/specification/tree/v0.15.6) (2024-09-06)
+## [v0.15.0](https://github.com/volkmarnissen/specification/tree/v0.15.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.5...v0.15.6)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.14.0...v0.15.0)
 
-## [v0.15.5](https://github.com/modbus2mqtt/specification/tree/v0.15.5) (2024-09-06)
+## [v0.14.0](https://github.com/volkmarnissen/specification/tree/v0.14.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.4...v0.15.5)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.13.0...v0.14.0)
 
-## [v0.15.4](https://github.com/modbus2mqtt/specification/tree/v0.15.4) (2024-09-06)
+## [v0.13.0](https://github.com/volkmarnissen/specification/tree/v0.13.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.2...v0.15.4)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.11.0...v0.13.0)
 
-## [v0.15.2](https://github.com/modbus2mqtt/specification/tree/v0.15.2) (2024-09-06)
+## [v0.11.0](https://github.com/volkmarnissen/specification/tree/v0.11.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.10.0...v0.11.0)
 
-## [v0.15.1](https://github.com/modbus2mqtt/specification/tree/v0.15.1) (2024-09-06)
+## [v0.10.0](https://github.com/volkmarnissen/specification/tree/v0.10.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.0...v0.15.1)
-
-## [v0.15.0](https://github.com/modbus2mqtt/specification/tree/v0.15.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.14.0...v0.15.0)
-
-## [v0.14.0](https://github.com/modbus2mqtt/specification/tree/v0.14.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.13.0...v0.14.0)
-
-## [v0.13.0](https://github.com/modbus2mqtt/specification/tree/v0.13.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.11.0...v0.13.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/specification/tree/v0.11.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.10.0...v0.11.0)
-
-## [v0.10.0](https://github.com/modbus2mqtt/specification/tree/v0.10.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,158 +1,132 @@
 # Changelog for specification
 
-## [Unreleased](https://github.com/modbus2mqtt/specification/tree/HEAD)
+## [v0.15.28](https://github.com/volkmarnissen/specification/tree/v0.15.28) (2025-01-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.29...HEAD)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.27...v0.15.28)
 
-**Merged pull requests:**
+## [v0.15.27](https://github.com/volkmarnissen/specification/tree/v0.15.27) (2025-01-15)
 
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#9](https://github.com/modbus2mqtt/specification/pull/9) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/specification/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#7](https://github.com/modbus2mqtt/specification/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
-- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/specification/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
-- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/specification/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
-- Fix Modbuscache, Add caching for modbusRTU [\#4](https://github.com/modbus2mqtt/specification/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.26...v0.15.27)
 
-## [v0.15.29](https://github.com/modbus2mqtt/specification/tree/v0.15.29) (2025-04-14)
+## [v0.15.26](https://github.com/volkmarnissen/specification/tree/v0.15.26) (2025-01-02)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.28...v0.15.29)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.25...v0.15.26)
 
-**Merged pull requests:**
+## [v0.15.25](https://github.com/volkmarnissen/specification/tree/v0.15.25) (2024-12-22)
 
-- Infrastructure fixes [\#3](https://github.com/modbus2mqtt/specification/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
-- Adding discrete inputs to data structures [\#2](https://github.com/modbus2mqtt/specification/pull/2) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.24...v0.15.25)
 
-## [v0.15.28](https://github.com/modbus2mqtt/specification/tree/v0.15.28) (2025-01-16)
+## [v0.15.24](https://github.com/volkmarnissen/specification/tree/v0.15.24) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.27...v0.15.28)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.23...v0.15.24)
 
-## [v0.15.27](https://github.com/modbus2mqtt/specification/tree/v0.15.27) (2025-01-15)
+## [v0.15.23](https://github.com/volkmarnissen/specification/tree/v0.15.23) (2024-12-13)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.26...v0.15.27)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.22...v0.15.23)
 
-## [v0.15.26](https://github.com/modbus2mqtt/specification/tree/v0.15.26) (2025-01-02)
+## [v0.15.22](https://github.com/volkmarnissen/specification/tree/v0.15.22) (2024-12-11)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.25...v0.15.26)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.21...v0.15.22)
 
-**Merged pull requests:**
+## [v0.15.21](https://github.com/volkmarnissen/specification/tree/v0.15.21) (2024-11-22)
 
-- Adding support for converting int32 and uint32 numbers [\#1](https://github.com/modbus2mqtt/specification/pull/1) ([arturmietek](https://github.com/arturmietek))
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.20...v0.15.21)
 
-## [v0.15.25](https://github.com/modbus2mqtt/specification/tree/v0.15.25) (2024-12-22)
+## [v0.15.20](https://github.com/volkmarnissen/specification/tree/v0.15.20) (2024-11-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.24...v0.15.25)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.19...v0.15.20)
 
-## [v0.15.24](https://github.com/modbus2mqtt/specification/tree/v0.15.24) (2024-12-13)
+## [v0.15.19](https://github.com/volkmarnissen/specification/tree/v0.15.19) (2024-11-14)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.23...v0.15.24)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.18...v0.15.19)
 
-## [v0.15.23](https://github.com/modbus2mqtt/specification/tree/v0.15.23) (2024-12-13)
+## [v0.15.18](https://github.com/volkmarnissen/specification/tree/v0.15.18) (2024-10-23)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.22...v0.15.23)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.17...v0.15.18)
 
-## [v0.15.22](https://github.com/modbus2mqtt/specification/tree/v0.15.22) (2024-12-11)
+## [v0.15.17](https://github.com/volkmarnissen/specification/tree/v0.15.17) (2024-10-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.21...v0.15.22)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.16...v0.15.17)
 
-## [v0.15.21](https://github.com/modbus2mqtt/specification/tree/v0.15.21) (2024-11-22)
+## [v0.15.16](https://github.com/volkmarnissen/specification/tree/v0.15.16) (2024-09-24)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.20...v0.15.21)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.15...v0.15.16)
 
-## [v0.15.20](https://github.com/modbus2mqtt/specification/tree/v0.15.20) (2024-11-16)
+## [v0.15.15](https://github.com/volkmarnissen/specification/tree/v0.15.15) (2024-09-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.19...v0.15.20)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.14...v0.15.15)
 
-## [v0.15.19](https://github.com/modbus2mqtt/specification/tree/v0.15.19) (2024-11-14)
+## [v0.15.14](https://github.com/volkmarnissen/specification/tree/v0.15.14) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.18...v0.15.19)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.13...v0.15.14)
 
-## [v0.15.18](https://github.com/modbus2mqtt/specification/tree/v0.15.18) (2024-10-23)
+## [v0.15.13](https://github.com/volkmarnissen/specification/tree/v0.15.13) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.17...v0.15.18)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.12...v0.15.13)
 
-## [v0.15.17](https://github.com/modbus2mqtt/specification/tree/v0.15.17) (2024-10-16)
+## [v0.15.12](https://github.com/volkmarnissen/specification/tree/v0.15.12) (2024-09-09)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.16...v0.15.17)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.11...v0.15.12)
 
-## [v0.15.16](https://github.com/modbus2mqtt/specification/tree/v0.15.16) (2024-09-24)
+## [v0.15.11](https://github.com/volkmarnissen/specification/tree/v0.15.11) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.15...v0.15.16)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.10...v0.15.11)
 
-## [v0.15.15](https://github.com/modbus2mqtt/specification/tree/v0.15.15) (2024-09-16)
+## [v0.15.10](https://github.com/volkmarnissen/specification/tree/v0.15.10) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.14...v0.15.15)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.9...v0.15.10)
 
-## [v0.15.14](https://github.com/modbus2mqtt/specification/tree/v0.15.14) (2024-09-09)
+## [v0.15.9](https://github.com/volkmarnissen/specification/tree/v0.15.9) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.13...v0.15.14)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.8...v0.15.9)
 
-## [v0.15.13](https://github.com/modbus2mqtt/specification/tree/v0.15.13) (2024-09-09)
+## [v0.15.8](https://github.com/volkmarnissen/specification/tree/v0.15.8) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.12...v0.15.13)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.7...v0.15.8)
 
-## [v0.15.12](https://github.com/modbus2mqtt/specification/tree/v0.15.12) (2024-09-09)
+## [v0.15.7](https://github.com/volkmarnissen/specification/tree/v0.15.7) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.11...v0.15.12)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.6...v0.15.7)
 
-## [v0.15.11](https://github.com/modbus2mqtt/specification/tree/v0.15.11) (2024-09-06)
+## [v0.15.6](https://github.com/volkmarnissen/specification/tree/v0.15.6) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.10...v0.15.11)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.5...v0.15.6)
 
-## [v0.15.10](https://github.com/modbus2mqtt/specification/tree/v0.15.10) (2024-09-06)
+## [v0.15.5](https://github.com/volkmarnissen/specification/tree/v0.15.5) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.9...v0.15.10)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.4...v0.15.5)
 
-## [v0.15.9](https://github.com/modbus2mqtt/specification/tree/v0.15.9) (2024-09-06)
+## [v0.15.4](https://github.com/volkmarnissen/specification/tree/v0.15.4) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.8...v0.15.9)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.2...v0.15.4)
 
-## [v0.15.8](https://github.com/modbus2mqtt/specification/tree/v0.15.8) (2024-09-06)
+## [v0.15.2](https://github.com/volkmarnissen/specification/tree/v0.15.2) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.7...v0.15.8)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.1...v0.15.2)
 
-## [v0.15.7](https://github.com/modbus2mqtt/specification/tree/v0.15.7) (2024-09-06)
+## [v0.15.1](https://github.com/volkmarnissen/specification/tree/v0.15.1) (2024-09-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.6...v0.15.7)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.0...v0.15.1)
 
-## [v0.15.6](https://github.com/modbus2mqtt/specification/tree/v0.15.6) (2024-09-06)
+## [v0.15.0](https://github.com/volkmarnissen/specification/tree/v0.15.0) (2024-08-16)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.5...v0.15.6)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.14.0...v0.15.0)
 
-## [v0.15.5](https://github.com/modbus2mqtt/specification/tree/v0.15.5) (2024-09-06)
+## [v0.14.0](https://github.com/volkmarnissen/specification/tree/v0.14.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.4...v0.15.5)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.13.0...v0.14.0)
 
-## [v0.15.4](https://github.com/modbus2mqtt/specification/tree/v0.15.4) (2024-09-06)
+## [v0.13.0](https://github.com/volkmarnissen/specification/tree/v0.13.0) (2024-08-06)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.2...v0.15.4)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.11.0...v0.13.0)
 
-## [v0.15.2](https://github.com/modbus2mqtt/specification/tree/v0.15.2) (2024-09-06)
+## [v0.11.0](https://github.com/volkmarnissen/specification/tree/v0.11.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.10.0...v0.11.0)
 
-## [v0.15.1](https://github.com/modbus2mqtt/specification/tree/v0.15.1) (2024-09-06)
+## [v0.10.0](https://github.com/volkmarnissen/specification/tree/v0.10.0) (2024-08-05)
 
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.0...v0.15.1)
-
-## [v0.15.0](https://github.com/modbus2mqtt/specification/tree/v0.15.0) (2024-08-16)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.14.0...v0.15.0)
-
-## [v0.14.0](https://github.com/modbus2mqtt/specification/tree/v0.14.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.13.0...v0.14.0)
-
-## [v0.13.0](https://github.com/modbus2mqtt/specification/tree/v0.13.0) (2024-08-06)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.11.0...v0.13.0)
-
-## [v0.11.0](https://github.com/modbus2mqtt/specification/tree/v0.11.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.10.0...v0.11.0)
-
-## [v0.10.0](https://github.com/modbus2mqtt/specification/tree/v0.10.0) (2024-08-05)
-
-[Full Changelog](https://github.com/modbus2mqtt/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
+[Full Changelog](https://github.com/volkmarnissen/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,132 +1,157 @@
 # Changelog for specification
 
-## [v0.15.28](https://github.com/volkmarnissen/specification/tree/v0.15.28) (2025-01-16)
+## [Unreleased](https://github.com/modbus2mqtt/specification/tree/HEAD)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.27...v0.15.28)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.29...HEAD)
 
-## [v0.15.27](https://github.com/volkmarnissen/specification/tree/v0.15.27) (2025-01-15)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.26...v0.15.27)
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#8](https://github.com/modbus2mqtt/specification/pull/8) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#7](https://github.com/modbus2mqtt/specification/pull/7) ([volkmarnissen](https://github.com/volkmarnissen))
+- \[bug\]Modbus Error Handling, Slave Specification Detection, TCP RTU bridge, Fixes [\#6](https://github.com/modbus2mqtt/specification/pull/6) ([volkmarnissen](https://github.com/volkmarnissen))
+- Modbus Error Handling and Monitoring [\#5](https://github.com/modbus2mqtt/specification/pull/5) ([volkmarnissen](https://github.com/volkmarnissen))
+- Fix Modbuscache, Add caching for modbusRTU [\#4](https://github.com/modbus2mqtt/specification/pull/4) ([volkmarnissen](https://github.com/volkmarnissen))
 
-## [v0.15.26](https://github.com/volkmarnissen/specification/tree/v0.15.26) (2025-01-02)
+## [v0.15.29](https://github.com/modbus2mqtt/specification/tree/v0.15.29) (2025-04-14)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.25...v0.15.26)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.28...v0.15.29)
 
-## [v0.15.25](https://github.com/volkmarnissen/specification/tree/v0.15.25) (2024-12-22)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.24...v0.15.25)
+- Infrastructure fixes [\#3](https://github.com/modbus2mqtt/specification/pull/3) ([volkmarnissen](https://github.com/volkmarnissen))
+- Adding discrete inputs to data structures [\#2](https://github.com/modbus2mqtt/specification/pull/2) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.15.24](https://github.com/volkmarnissen/specification/tree/v0.15.24) (2024-12-13)
+## [v0.15.28](https://github.com/modbus2mqtt/specification/tree/v0.15.28) (2025-01-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.23...v0.15.24)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.27...v0.15.28)
 
-## [v0.15.23](https://github.com/volkmarnissen/specification/tree/v0.15.23) (2024-12-13)
+## [v0.15.27](https://github.com/modbus2mqtt/specification/tree/v0.15.27) (2025-01-15)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.22...v0.15.23)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.26...v0.15.27)
 
-## [v0.15.22](https://github.com/volkmarnissen/specification/tree/v0.15.22) (2024-12-11)
+## [v0.15.26](https://github.com/modbus2mqtt/specification/tree/v0.15.26) (2025-01-02)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.21...v0.15.22)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.25...v0.15.26)
 
-## [v0.15.21](https://github.com/volkmarnissen/specification/tree/v0.15.21) (2024-11-22)
+**Merged pull requests:**
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.20...v0.15.21)
+- Adding support for converting int32 and uint32 numbers [\#1](https://github.com/modbus2mqtt/specification/pull/1) ([arturmietek](https://github.com/arturmietek))
 
-## [v0.15.20](https://github.com/volkmarnissen/specification/tree/v0.15.20) (2024-11-16)
+## [v0.15.25](https://github.com/modbus2mqtt/specification/tree/v0.15.25) (2024-12-22)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.19...v0.15.20)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.24...v0.15.25)
 
-## [v0.15.19](https://github.com/volkmarnissen/specification/tree/v0.15.19) (2024-11-14)
+## [v0.15.24](https://github.com/modbus2mqtt/specification/tree/v0.15.24) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.18...v0.15.19)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.23...v0.15.24)
 
-## [v0.15.18](https://github.com/volkmarnissen/specification/tree/v0.15.18) (2024-10-23)
+## [v0.15.23](https://github.com/modbus2mqtt/specification/tree/v0.15.23) (2024-12-13)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.17...v0.15.18)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.22...v0.15.23)
 
-## [v0.15.17](https://github.com/volkmarnissen/specification/tree/v0.15.17) (2024-10-16)
+## [v0.15.22](https://github.com/modbus2mqtt/specification/tree/v0.15.22) (2024-12-11)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.16...v0.15.17)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.21...v0.15.22)
 
-## [v0.15.16](https://github.com/volkmarnissen/specification/tree/v0.15.16) (2024-09-24)
+## [v0.15.21](https://github.com/modbus2mqtt/specification/tree/v0.15.21) (2024-11-22)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.15...v0.15.16)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.20...v0.15.21)
 
-## [v0.15.15](https://github.com/volkmarnissen/specification/tree/v0.15.15) (2024-09-16)
+## [v0.15.20](https://github.com/modbus2mqtt/specification/tree/v0.15.20) (2024-11-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.14...v0.15.15)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.19...v0.15.20)
 
-## [v0.15.14](https://github.com/volkmarnissen/specification/tree/v0.15.14) (2024-09-09)
+## [v0.15.19](https://github.com/modbus2mqtt/specification/tree/v0.15.19) (2024-11-14)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.13...v0.15.14)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.18...v0.15.19)
 
-## [v0.15.13](https://github.com/volkmarnissen/specification/tree/v0.15.13) (2024-09-09)
+## [v0.15.18](https://github.com/modbus2mqtt/specification/tree/v0.15.18) (2024-10-23)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.12...v0.15.13)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.17...v0.15.18)
 
-## [v0.15.12](https://github.com/volkmarnissen/specification/tree/v0.15.12) (2024-09-09)
+## [v0.15.17](https://github.com/modbus2mqtt/specification/tree/v0.15.17) (2024-10-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.11...v0.15.12)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.16...v0.15.17)
 
-## [v0.15.11](https://github.com/volkmarnissen/specification/tree/v0.15.11) (2024-09-06)
+## [v0.15.16](https://github.com/modbus2mqtt/specification/tree/v0.15.16) (2024-09-24)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.10...v0.15.11)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.15...v0.15.16)
 
-## [v0.15.10](https://github.com/volkmarnissen/specification/tree/v0.15.10) (2024-09-06)
+## [v0.15.15](https://github.com/modbus2mqtt/specification/tree/v0.15.15) (2024-09-16)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.9...v0.15.10)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.14...v0.15.15)
 
-## [v0.15.9](https://github.com/volkmarnissen/specification/tree/v0.15.9) (2024-09-06)
+## [v0.15.14](https://github.com/modbus2mqtt/specification/tree/v0.15.14) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.8...v0.15.9)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.13...v0.15.14)
 
-## [v0.15.8](https://github.com/volkmarnissen/specification/tree/v0.15.8) (2024-09-06)
+## [v0.15.13](https://github.com/modbus2mqtt/specification/tree/v0.15.13) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.7...v0.15.8)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.12...v0.15.13)
 
-## [v0.15.7](https://github.com/volkmarnissen/specification/tree/v0.15.7) (2024-09-06)
+## [v0.15.12](https://github.com/modbus2mqtt/specification/tree/v0.15.12) (2024-09-09)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.6...v0.15.7)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.11...v0.15.12)
 
-## [v0.15.6](https://github.com/volkmarnissen/specification/tree/v0.15.6) (2024-09-06)
+## [v0.15.11](https://github.com/modbus2mqtt/specification/tree/v0.15.11) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.5...v0.15.6)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.10...v0.15.11)
 
-## [v0.15.5](https://github.com/volkmarnissen/specification/tree/v0.15.5) (2024-09-06)
+## [v0.15.10](https://github.com/modbus2mqtt/specification/tree/v0.15.10) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.4...v0.15.5)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.9...v0.15.10)
 
-## [v0.15.4](https://github.com/volkmarnissen/specification/tree/v0.15.4) (2024-09-06)
+## [v0.15.9](https://github.com/modbus2mqtt/specification/tree/v0.15.9) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.2...v0.15.4)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.8...v0.15.9)
 
-## [v0.15.2](https://github.com/volkmarnissen/specification/tree/v0.15.2) (2024-09-06)
+## [v0.15.8](https://github.com/modbus2mqtt/specification/tree/v0.15.8) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.1...v0.15.2)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.7...v0.15.8)
 
-## [v0.15.1](https://github.com/volkmarnissen/specification/tree/v0.15.1) (2024-09-06)
+## [v0.15.7](https://github.com/modbus2mqtt/specification/tree/v0.15.7) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.15.0...v0.15.1)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.6...v0.15.7)
 
-## [v0.15.0](https://github.com/volkmarnissen/specification/tree/v0.15.0) (2024-08-16)
+## [v0.15.6](https://github.com/modbus2mqtt/specification/tree/v0.15.6) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.14.0...v0.15.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.5...v0.15.6)
 
-## [v0.14.0](https://github.com/volkmarnissen/specification/tree/v0.14.0) (2024-08-06)
+## [v0.15.5](https://github.com/modbus2mqtt/specification/tree/v0.15.5) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.13.0...v0.14.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.4...v0.15.5)
 
-## [v0.13.0](https://github.com/volkmarnissen/specification/tree/v0.13.0) (2024-08-06)
+## [v0.15.4](https://github.com/modbus2mqtt/specification/tree/v0.15.4) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.11.0...v0.13.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.2...v0.15.4)
 
-## [v0.11.0](https://github.com/volkmarnissen/specification/tree/v0.11.0) (2024-08-05)
+## [v0.15.2](https://github.com/modbus2mqtt/specification/tree/v0.15.2) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/v0.10.0...v0.11.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.1...v0.15.2)
 
-## [v0.10.0](https://github.com/volkmarnissen/specification/tree/v0.10.0) (2024-08-05)
+## [v0.15.1](https://github.com/modbus2mqtt/specification/tree/v0.15.1) (2024-09-06)
 
-[Full Changelog](https://github.com/volkmarnissen/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.15.0...v0.15.1)
+
+## [v0.15.0](https://github.com/modbus2mqtt/specification/tree/v0.15.0) (2024-08-16)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.14.0...v0.15.0)
+
+## [v0.14.0](https://github.com/modbus2mqtt/specification/tree/v0.14.0) (2024-08-06)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.13.0...v0.14.0)
+
+## [v0.13.0](https://github.com/modbus2mqtt/specification/tree/v0.13.0) (2024-08-06)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.11.0...v0.13.0)
+
+## [v0.11.0](https://github.com/modbus2mqtt/specification/tree/v0.11.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/v0.10.0...v0.11.0)
+
+## [v0.10.0](https://github.com/modbus2mqtt/specification/tree/v0.10.0) (2024-08-05)
+
+[Full Changelog](https://github.com/modbus2mqtt/specification/compare/85794b96890740e84fdfa76f0d2fe3737b18f58e...v0.10.0)
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,7 +1626,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#482ce60f03c8e0ea5c8e12b1c76a1bb1d12a9528",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#5c9c2f4f6e66d1e3bcb861547c0b2e72691a2dce",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1626,7 +1626,7 @@
     },
     "node_modules/@modbus2mqtt/specification.shared": {
       "version": "0.10.11",
-      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#5c9c2f4f6e66d1e3bcb861547c0b2e72691a2dce",
+      "resolved": "git+ssh://git@github.com/modbus2mqtt/specification.shared.git#482ce60f03c8e0ea5c8e12b1c76a1bb1d12a9528",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {


### PR DESCRIPTION
Add number of processed calls to Modbus Status
### Dependant Pullrequests
|Repository|Pull Request|
|----|----|
|[specification.shared](https://github.com/modbus2mqtt/specification.shared/pull/8)|8|
|[specification](https://github.com/modbus2mqtt/specification/pull/10)|10|
|[server.shared](https://github.com/modbus2mqtt/server.shared/pull/5)|5|
|[angular](https://github.com/modbus2mqtt/angular/pull/11)|11|
|[server](https://github.com/modbus2mqtt/server/pull/118)|118|
